### PR TITLE
fix: use highp in examples

### DIFF
--- a/shaders/blue-light-filter.glsl
+++ b/shaders/blue-light-filter.glsl
@@ -1,6 +1,6 @@
 // from https://github.com/hyprwm/Hyprland/issues/1140#issuecomment-1335128437
 
-precision mediump float;
+precision highp float;
 varying vec2 v_texcoord;
 uniform sampler2D tex;
 

--- a/shaders/vibrance.glsl
+++ b/shaders/vibrance.glsl
@@ -1,6 +1,6 @@
 // from https://github.com/hyprwm/Hyprland/issues/1140#issuecomment-1614863627
 
-precision mediump float;
+precision highp float;
 varying vec2 v_texcoord;
 uniform sampler2D tex;
 


### PR DESCRIPTION
Otherwise the shader makes text look blurry/pixelated.

For reference: https://github.com/hyprwm/Hyprland/commit/fbf5ba87ce57752653f3bebf6e2be090c702836e