### PR TITLE
Add the gradual_shift_duration option to shaders, scheduled in systemd

### DIFF
--- a/shaders/blue-light-filter.glsl.mustache
+++ b/shaders/blue-light-filter.glsl.mustache
@@ -6,6 +6,8 @@ uniform sampler2D tex;
 
 const float temperature = 2600.0;
 const float temperatureStrength = 1.0;
+// This variable is automatically handled with the `gradual_switch_duration` config variable
+const float gradualPercentage = {{#gradualPercentage}}{{.}}{{/gradualPercentage}}{{^gradualPercentage}}1.0{{/gradualPercentage}};
 
 #define WithQuickAndDirtyLuminancePreservation
 const float LuminancePreservationFactor = 1.0;
@@ -35,7 +37,7 @@ void main() {
                  LuminancePreservationFactor);
 #endif
 
-    color = mix(color, color * colorTemperatureToRGB(temperature), temperatureStrength);
+    color = mix(color, color * colorTemperatureToRGB(temperature), temperatureStrength * gradualPercentage);
 
     vec4 outCol = vec4(color, pixColor[3]);
 

--- a/src/hyprshade/cli/install.py
+++ b/src/hyprshade/cli/install.py
@@ -28,6 +28,8 @@ def install(obj: ContextObject):
         "service",
         f"""[Unit]
 Description=Apply screen filter
+StartLimitBurst=10
+StartLimitIntervalSec=5
 
 [Service]
 Type=oneshot
@@ -41,6 +43,7 @@ ExecStart={shlex.quote(script_path)} auto
 Description=Apply screen filter on schedule
 
 [Timer]
+AccuracySec=1s
 {timer_config}
 
 [Install]

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -22,6 +22,7 @@ def test_example_config(request: pytest.FixtureRequest):
                 "name": "blue-light-filter",
                 "start_time": time(19, 0, 0),
                 "end_time": time(6, 0, 0),
+                "gradual_shift_duration": 10,
                 "default": False,
                 "config": None,
             },


### PR DESCRIPTION
Same feature as https://github.com/loqusion/hyprshade/pull/30, different implementation.

This PR adds the `gradual_shift_duration` option to shaders in hyprshade.toml.

The option will set scheduled steps(to discuss) to increment the `gradualPercentage` glsl variable if the concerned shader is a templage. If the shader is not a template or does not implement the `gradualPercentage` variable, `gradual_shift_duration` will have no effect.