### PR TITLE
Add the gradual_shift_duration option to shaders while blocking execution

### DIFF
--- a/shaders/blue-light-filter.glsl.mustache
+++ b/shaders/blue-light-filter.glsl.mustache
@@ -26,6 +26,8 @@ const float Temperature = float({{#nc}}{{temperature}} ? 2600.0{{/nc}});
  * @max 1.0
  */
 const float Strength = float({{#nc}}{{strength}} ? 1.0{{/nc}});
+// This variable is automatically handled with the `gradual_switch_duration` config variable
+const float gradualPercentage = {{#nc}}{{gradualPercentage}} ? 1.0{{/nc}};
 
 #define WithQuickAndDirtyLuminancePreservation
 const float LuminancePreservationFactor = 1.0;
@@ -55,7 +57,7 @@ void main() {
                  LuminancePreservationFactor);
 #endif
 
-    color = mix(color, color * colorTemperatureToRGB(Temperature), Strength);
+    color = mix(color, color * colorTemperatureToRGB(temperature), Strength * gradualPercentage);
 
     vec4 outCol = vec4(color, pixColor[3]);
 

--- a/src/hyprshade/cli/__init__.py
+++ b/src/hyprshade/cli/__init__.py
@@ -38,8 +38,9 @@ COMMON_DECORATORS: Final = [
 @click.version_option(help="Show the version and exit")
 @click.help_option(help="Show this message and exit")
 @click.option("-v", "--verbose", is_flag=True, help="Enable verbose output")
+@click.option("--skip-gradual-shift", is_flag=True, help="Skip the gradual shift if it is configured for the shader")
 @click.pass_context
-def cli(ctx: click.Context, verbose: bool):
+def cli(ctx: click.Context, verbose: bool, skip_gradual_shift: bool):
     """Improved UX for Hyprland shaders
 
     For more detailed documentation, visit the project's GitHub page:
@@ -50,7 +51,7 @@ def cli(ctx: click.Context, verbose: bool):
     logging.basicConfig(level=level)
 
     try:
-        config = Config()
+        config = Config(skip_gradual_shift=skip_gradual_shift)
     except FileNotFoundError:
         config = None
     ctx.obj = ContextObject(config)

--- a/src/hyprshade/cli/__init__.py
+++ b/src/hyprshade/cli/__init__.py
@@ -7,6 +7,7 @@ import click
 
 from hyprshade.cli.utils import ContextObject
 from hyprshade.config.core import Config
+from hyprshade.config.model import Options
 
 from .auto import auto
 from .current import current
@@ -50,8 +51,10 @@ def cli(ctx: click.Context, verbose: bool, skip_gradual_shift: bool):
     level = logging.DEBUG if verbose else logging.WARNING
     logging.basicConfig(level=level)
 
+    options = Options(skip_gradual_shift)
+
     try:
-        config = Config(skip_gradual_shift=skip_gradual_shift)
+        config = Config(options=options)
     except FileNotFoundError:
         config = None
     ctx.obj = ContextObject(config)

--- a/src/hyprshade/cli/utils.py
+++ b/src/hyprshade/cli/utils.py
@@ -79,7 +79,11 @@ class ShaderParamType(click.ParamType):
         lazy_variables = (
             config.lazy_shader_variables(value) if config is not None else None
         )
-        return Shader(value, lazy_variables)
+        shader_conf = config.shader_config(value) if config is not None else None
+        gradual_shift_duration = 0
+        if shader_conf is not None:
+            gradual_shift_duration = shader_conf.gradual_shift_duration if shader_conf.gradual_shift_duration is not None else 0
+        return Shader(value, lazy_variables, gradual_shift_duration)
 
     def shell_complete(
         self, ctx: click.Context, param: click.Parameter, incomplete: str

--- a/src/hyprshade/cli/utils.py
+++ b/src/hyprshade/cli/utils.py
@@ -79,11 +79,10 @@ class ShaderParamType(click.ParamType):
         lazy_variables = (
             config.lazy_shader_variables(value) if config is not None else None
         )
-        shader_conf = config.shader_config(value) if config is not None else None
-        gradual_shift_duration = 0
-        if shader_conf is not None:
-            gradual_shift_duration = shader_conf.gradual_shift_duration if shader_conf.gradual_shift_duration is not None else 0
-        return Shader(value, lazy_variables, gradual_shift_duration)
+        shader_conf = (
+                config.shader_config(value) if config is not None else None
+        )
+        return Shader(value, lazy_variables, shader_conf)
 
     def shell_complete(
         self, ctx: click.Context, param: click.Parameter, incomplete: str

--- a/src/hyprshade/config/core.py
+++ b/src/hyprshade/config/core.py
@@ -8,7 +8,7 @@ from more_itertools import first_true
 
 from hyprshade.utils.xdg import user_config_dir
 
-from .model import RootConfig, ShaderConfig
+from .model import RootConfig, ShaderConfig, Options
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -17,11 +17,11 @@ if TYPE_CHECKING:
 class Config:
     model: RootConfig
 
-    def __init__(self, path: str | None = None, skip_gradual_shift: bool | None = None):
+    def __init__(self, path: str | None = None, options: Options = Options()):
         path = path or Config._get_path()
         if path is None:
             self.raise_not_found()
-        self.model = RootConfig(Config._load(path), path=path, skip_gradual_shift=skip_gradual_shift)
+        self.model = RootConfig(Config._load(path), path=path, options=options)
 
     def shader_config(self, name_or_path: str) -> ShaderConfig | None:
         from hyprshade.shader.core import Shader

--- a/src/hyprshade/config/core.py
+++ b/src/hyprshade/config/core.py
@@ -17,11 +17,11 @@ if TYPE_CHECKING:
 class Config:
     model: RootConfig
 
-    def __init__(self, path: str | None = None):
+    def __init__(self, path: str | None = None, skip_gradual_shift: bool | None = None):
         path = path or Config._get_path()
         if path is None:
             self.raise_not_found()
-        self.model = RootConfig(Config._load(path), path=path)
+        self.model = RootConfig(Config._load(path), path=path, skip_gradual_shift=skip_gradual_shift)
 
     def shader_config(self, name_or_path: str) -> ShaderConfig | None:
         from hyprshade.shader.core import Shader

--- a/src/hyprshade/config/model.py
+++ b/src/hyprshade/config/model.py
@@ -35,13 +35,16 @@ def parse_config(obj):
         for o in obj.values():
             parse_config(o)
 
+class Options:
+    def __init__(self, skip_gradual_shift: bool | None = False):
+        self.skip_gradual_shift = skip_gradual_shift
 
 class LazyConfig:
-    def __init__(self, config_dict: dict, *, path: str, steps: tuple = (), skip_gradual_shift: bool | None = None):
+    def __init__(self, config_dict: dict, *, path: str, steps: tuple = (), options: Options):
         self.raw_data = config_dict
         self.path = path
         self.steps = steps
-        self._skip_gradual_shift = skip_gradual_shift
+        self.options = options
 
     def parse_fields(self):
         for attribute in self.__dict__:
@@ -109,7 +112,7 @@ class RootConfig(LazyConfig):
                             found_default = True
 
                         field_shaders.append(
-                            ShaderConfig(shader, path=self.path, steps=(step, str(i)), skip_gradual_shift=self._skip_gradual_shift)
+                            ShaderConfig(shader, path=self.path, steps=(step, str(i)), options=self.options)
                         )
 
                 self._field_shaders = field_shaders
@@ -177,7 +180,7 @@ class ShaderConfig(LazyConfig):
     @property
     def gradual_shift_duration(self) -> int | None:
         if self._field_gradual_shift_duration is MISSING:
-            if not self._skip_gradual_shift:
+            if not self.options.skip_gradual_shift:
                 if "gradual_shift_duration" in self.raw_data:
                     gradual_shift_duration = self.raw_data["gradual_shift_duration"]
 

--- a/src/hyprshade/config/schedule.py
+++ b/src/hyprshade/config/schedule.py
@@ -27,7 +27,11 @@ class Schedule:
     def scheduled_shader(self, t: time) -> Shader | None:
         for entry in self._resolved_entries():
             if is_time_between(t, entry.start_time, entry.end_time):
-                return Shader(entry.name, self.config.lazy_shader_variables(entry.name))
+                shader_conf = self.config.shader_config(entry.name)
+                gradual_shift_duration = 0
+                if shader_conf is not None:
+                    gradual_shift_duration = shader_conf.gradual_shift_duration if shader_conf.gradual_shift_duration is not None else 0
+                return Shader(entry.name, self.config.lazy_shader_variables(entry.name), gradual_shift_duration)
 
         return self.default_shader
 
@@ -46,7 +50,11 @@ class Schedule:
         default = only(filter(lambda s: s.default, self.config.model.shaders))
         if not default:
             return None
-        return Shader(default.name, self.config.lazy_shader_variables(default.name))
+        shader_conf = self.config.shader_config(default.name)
+        gradual_shift_duration = 0
+        if shader_conf is not None:
+            gradual_shift_duration = shader_conf.gradual_shift_duration if shader_conf.gradual_shift_duration is not None else 0
+        return Shader(default.name, self.config.lazy_shader_variables(default.name), gradual_shift_duration)
 
     def _resolved_entries(self) -> Iterator[ResolvedEntry]:
         if not (entries := self._entries()):

--- a/src/hyprshade/config/schedule.py
+++ b/src/hyprshade/config/schedule.py
@@ -27,11 +27,7 @@ class Schedule:
     def scheduled_shader(self, t: time) -> Shader | None:
         for entry in self._resolved_entries():
             if is_time_between(t, entry.start_time, entry.end_time):
-                shader_conf = self.config.shader_config(entry.name)
-                gradual_shift_duration = 0
-                if shader_conf is not None:
-                    gradual_shift_duration = shader_conf.gradual_shift_duration if shader_conf.gradual_shift_duration is not None else 0
-                return Shader(entry.name, self.config.lazy_shader_variables(entry.name), gradual_shift_duration)
+                return Shader(entry.name, self.config.lazy_shader_variables(entry.name), self.config.shader_config(entry.name))
 
         return self.default_shader
 
@@ -50,11 +46,7 @@ class Schedule:
         default = only(filter(lambda s: s.default, self.config.model.shaders))
         if not default:
             return None
-        shader_conf = self.config.shader_config(default.name)
-        gradual_shift_duration = 0
-        if shader_conf is not None:
-            gradual_shift_duration = shader_conf.gradual_shift_duration if shader_conf.gradual_shift_duration is not None else 0
-        return Shader(default.name, self.config.lazy_shader_variables(default.name), gradual_shift_duration)
+        return Shader(default.name, self.config.lazy_shader_variables(default.name), self.config.shader_config(default.name))
 
     def _resolved_entries(self) -> Iterator[ResolvedEntry]:
         if not (entries := self._entries()):


### PR DESCRIPTION
Same feature as https://github.com/loqusion/hyprshade/pull/29, different implementation.

This PR adds the gradual_shift_duration option to shaders in hyprshade.toml.

With the option set, `hyprshade on` will block execution for the time set in `gradual_shift_duration` and gradually set the shader while increasing the `gradualPercentage` glsl variable.

If the concerned shader is not a template or does not implement the `gradualPercentage` variable, `gradual_shift_duration` will have no effect.