### PR TITLE
Update shaders to use GLES version 3.0 (latest)

### DIFF
--- a/shaders/blue-light-filter.glsl.mustache
+++ b/shaders/blue-light-filter.glsl.mustache
@@ -6,9 +6,12 @@
  * Source: https://github.com/hyprwm/Hyprland/issues/1140#issuecomment-1335128437
  */
 
+#version 300 es
 precision highp float;
-varying vec2 v_texcoord;
+
+in vec2 v_texcoord;
 uniform sampler2D tex;
+out vec4 fragColor;
 
 /**
  * Color temperature in Kelvin.
@@ -34,32 +37,33 @@ const float LuminancePreservationFactor = 1.0;
 // valid from 1000 to 40000 K (and additionally 0 for pure full white)
 vec3 colorTemperatureToRGB(const in float temperature) {
     // values from: http://blenderartists.org/forum/showthread.php?270332-OSL-Goodness&p=2268693&viewfull=1#post2268693
-    mat3 m = (temperature <= 6500.0) ? mat3(vec3(0.0, -2902.1955373783176, -8257.7997278925690),
-                                            vec3(0.0, 1669.5803561666639, 2575.2827530017594),
-                                            vec3(1.0, 1.3302673723350029, 1.8993753891711275))
-                                     : mat3(vec3(1745.0425298314172, 1216.6168361476490, -8257.7997278925690),
-                                            vec3(-2666.3474220535695, -2173.1012343082230, 2575.2827530017594),
-                                            vec3(0.55995389139931482, 0.70381203140554553, 1.8993753891711275));
-    return mix(clamp(vec3(m[0] / (vec3(clamp(temperature, 1000.0, 40000.0)) + m[1]) + m[2]), vec3(0.0), vec3(1.0)),
-               vec3(1.0), smoothstep(1000.0, 0.0, temperature));
+    mat3 m = (temperature <= 6500.0)
+        ? mat3(vec3(0.0, -2902.1955373783176, -8257.7997278925690),
+               vec3(0.0, 1669.5803561666639, 2575.2827530017594),
+               vec3(1.0, 1.3302673723350029, 1.8993753891711275))
+        : mat3(vec3(1745.0425298314172, 1216.6168361476490, -8257.7997278925690),
+               vec3(-2666.3474220535695, -2173.1012343082230, 2575.2827530017594),
+               vec3(0.55995389139931482, 0.70381203140554553, 1.8993753891711275));
+
+    return mix(
+        clamp(m[0] / (vec3(clamp(temperature, 1000.0, 40000.0)) + m[1]) + m[2], 0.0, 1.0),
+        vec3(1.0),
+        smoothstep(1000.0, 0.0, temperature)
+    );
 }
 
 void main() {
-    vec4 pixColor = texture2D(tex, v_texcoord);
-
-    // RGB
-    vec3 color = vec3(pixColor[0], pixColor[1], pixColor[2]);
+    vec4 pixColor = texture(tex, v_texcoord);
+    vec3 color = pixColor.rgb;
 
 #ifdef WithQuickAndDirtyLuminancePreservation
-    color *= mix(1.0, dot(color, vec3(0.2126, 0.7152, 0.0722)) / max(dot(color, vec3(0.2126, 0.7152, 0.0722)), 1e-5),
-                 LuminancePreservationFactor);
+    float lum = dot(color, vec3(0.2126, 0.7152, 0.0722));
+    color *= mix(1.0, lum / max(lum, 1e-5), LuminancePreservationFactor);
 #endif
 
     color = mix(color, color * colorTemperatureToRGB(Temperature), Strength);
 
-    vec4 outCol = vec4(color, pixColor[3]);
-
-    gl_FragColor = outCol;
+    fragColor = vec4(color, pixColor.a);
 }
 
 // vim: ft=glsl

--- a/shaders/color-filter.glsl.mustache
+++ b/shaders/color-filter.glsl.mustache
@@ -7,9 +7,12 @@
  * Source: https://godotshaders.com/shader/colorblindness-correction-shader/
  */
 
+#version 300 es
 precision highp float;
-varying vec2 v_texcoord;
+
+in vec2 v_texcoord;
 uniform sampler2D tex;
+out vec4 fragColor;
 
 /**
  * Strength of filter.
@@ -36,40 +39,47 @@ const int BLUEYELLOW = TRITANOPIA;
 const int Type = {{#nc}}{{type}} ? PROTANOPIA{{/nc}};
 
 void main() {
-    vec4 pixColor = texture2D(tex, v_texcoord);
+    vec4 pixColor = texture(tex, v_texcoord);
 
-    float L = (17.8824 * pixColor.r) + (43.5161 * pixColor.g) + (4.11935 * pixColor.b);
-    float M = (3.45565 * pixColor.r) + (27.1554 * pixColor.g) + (3.86714 * pixColor.b);
-    float S = (0.0299566 * pixColor.r) + (0.184309 * pixColor.g) + (1.46709 * pixColor.b);
+    // Convert to LMS color space
+    float L = 17.8824 * pixColor.r + 43.5161 * pixColor.g + 4.11935 * pixColor.b;
+    float M = 3.45565 * pixColor.r + 27.1554 * pixColor.g + 3.86714 * pixColor.b;
+    float S = 0.0299566 * pixColor.r + 0.184309 * pixColor.g + 1.46709 * pixColor.b;
 
     float l, m, s;
+
     if (Type == PROTANOPIA) {
-        l = 0.0 * L + 2.02344 * M + -2.52581 * S;
-        m = 0.0 * L + 1.0 * M + 0.0 * S;
-        s = 0.0 * L + 0.0 * M + 1.0 * S;
+        l = 2.02344 * M - 2.52581 * S;
+        m = M;
+        s = S;
     } else if (Type == DEUTERANOPIA) {
-        l = 1.0 * L + 0.0 * M + 0.0 * S;
-        m = 0.494207 * L + 0.0 * M + 1.24827 * S;
-        s = 0.0 * L + 0.0 * M + 1.0 * S;
+        l = L;
+        m = 0.494207 * L + 1.24827 * S;
+        s = S;
     } else if (Type == TRITANOPIA) {
-        l = 1.0 * L + 0.0 * M + 0.0 * S;
-        m = 0.0 * L + 1.0 * M + 0.0 * S;
-        s = -0.395913 * L + 0.801109 * M + 0.0 * S;
+        l = L;
+        m = M;
+        s = -0.395913 * L + 0.801109 * M;
     }
 
+    // Convert back to RGB
     vec4 error;
-    error.r = (0.0809444479 * l) + (-0.130504409 * m) + (0.116721066 * s);
-    error.g = (-0.0102485335 * l) + (0.0540193266 * m) + (-0.113614708 * s);
-    error.b = (-0.000365296938 * l) + (-0.00412161469 * m) + (0.693511405 * s);
+    error.r = 0.0809444479 * l + -0.130504409 * m + 0.116721066 * s;
+    error.g = -0.0102485335 * l + 0.0540193266 * m - 0.113614708 * s;
+    error.b = -0.000365296938 * l - 0.00412161469 * m + 0.693511405 * s;
     error.a = 1.0;
+
     vec4 diff = pixColor - error;
+
+    // Apply correction
     vec4 correction;
     correction.r = 0.0;
-    correction.g = (diff.r * 0.7) + (diff.g * 1.0);
-    correction.b = (diff.r * 0.7) + (diff.b * 1.0);
-    correction = mix(pixColor, pixColor + correction, Strength);
+    correction.g = diff.r * 0.7 + diff.g;
+    correction.b = diff.r * 0.7 + diff.b;
 
-    gl_FragColor = vec4(correction);
+    vec4 result = mix(pixColor, pixColor + correction, Strength);
+
+    fragColor = vec4(result.rgb, pixColor.a);
 }
 
 // vim: ft=glsl

--- a/shaders/grayscale.glsl.mustache
+++ b/shaders/grayscale.glsl.mustache
@@ -2,9 +2,12 @@
  * Grayscale
  */
 
+#version 300 es
 precision highp float;
-varying vec2 v_texcoord;
+
+in vec2 v_texcoord;
 uniform sampler2D tex;
+out vec4 fragColor;
 
 // Enum for type of grayscale conversion
 const int LUMINOSITY = 0;
@@ -23,14 +26,14 @@ const int HDR = 2;
 
 /**
  * Formula used to calculate relative luminance.
- * (Only applies to type = "luminosity".)
+ * (Only applies when type = "luminosity".)
  */
 const int LuminosityType = {{#nc}}{{luminosity_type}} ? HDR{{/nc}};
 
 void main() {
-    vec4 pixColor = texture2D(tex, v_texcoord);
+    vec4 pixColor = texture(tex, v_texcoord);
+    float gray = 0.0;
 
-    float gray;
     if (Type == LUMINOSITY) {
         // https://en.wikipedia.org/wiki/Grayscale#Luma_coding_in_video_systems
         if (LuminosityType == PAL) {
@@ -41,15 +44,14 @@ void main() {
             gray = dot(pixColor.rgb, vec3(0.2627, 0.6780, 0.0593));
         }
     } else if (Type == LIGHTNESS) {
-        float maxPixColor = max(pixColor.r, max(pixColor.g, pixColor.b));
-        float minPixColor = min(pixColor.r, min(pixColor.g, pixColor.b));
-        gray = (maxPixColor + minPixColor) / 2.0;
+        float maxColor = max(pixColor.r, max(pixColor.g, pixColor.b));
+        float minColor = min(pixColor.r, min(pixColor.g, pixColor.b));
+        gray = (maxColor + minColor) / 2.0;
     } else if (Type == AVERAGE) {
         gray = (pixColor.r + pixColor.g + pixColor.b) / 3.0;
     }
-    vec3 grayscale = vec3(gray);
 
-    gl_FragColor = vec4(grayscale, pixColor.a);
+    fragColor = vec4(vec3(gray), pixColor.a);
 }
 
 // vim: ft=glsl

--- a/shaders/invert-colors.glsl
+++ b/shaders/invert-colors.glsl
@@ -1,8 +1,11 @@
+#version 300 es
 precision highp float;
-varying vec2 v_texcoord;
+
+in vec2 v_texcoord;
 uniform sampler2D tex;
+out vec4 fragColor;
 
 void main() {
-    vec4 pixColor = texture2D(tex, v_texcoord);
-    gl_FragColor = vec4(1.0 - pixColor.r, 1.0 - pixColor.g, 1.0 - pixColor.b, pixColor.a);
+    vec4 pixColor = texture(tex, v_texcoord);
+    fragColor = vec4(1.0 - pixColor.rgb, pixColor.a);
 }

--- a/shaders/vibrance.glsl.mustache
+++ b/shaders/vibrance.glsl.mustache
@@ -7,9 +7,12 @@
  * Source: https://github.com/hyprwm/Hyprland/issues/1140#issuecomment-1614863627
  */
 
+#version 300 es
 precision highp float;
-varying vec2 v_texcoord;
+
+in vec2 v_texcoord;
 uniform sampler2D tex;
+out vec4 fragColor;
 
 // see https://github.com/CeeJayDK/SweetFX/blob/a792aee788c6203385a858ebdea82a77f81c67f0/Shaders/Vibrance.fx#L20-L30
 
@@ -37,26 +40,20 @@ const float Strength = float({{#nc}}{{strength}} ? 0.15{{/nc}});
 const vec3 VIB_coeffVibrance = Balance * -Strength;
 
 void main() {
-    vec4 pixColor = texture2D(tex, v_texcoord);
-    vec3 color = vec3(pixColor[0], pixColor[1], pixColor[2]);
+    vec4 pixColor = texture(tex, v_texcoord);
+    vec3 color = pixColor.rgb;
 
-    // vec3 VIB_coefLuma = vec3(0.333333, 0.333334, 0.333333); // was for `if VIB_LUMA == 1`
-    vec3 VIB_coefLuma = vec3(0.212656, 0.715158, 0.072186); // try both and see which one looks nicer.
-
+    vec3 VIB_coefLuma = vec3(0.212656, 0.715158, 0.072186);
     float luma = dot(VIB_coefLuma, color);
 
-    float max_color = max(color[0], max(color[1], color[2]));
-    float min_color = min(color[0], min(color[1], color[2]));
-
+    float max_color = max(color.r, max(color.g, color.b));
+    float min_color = min(color.r, min(color.g, color.b));
     float color_saturation = max_color - min_color;
 
-    vec3 p_col = vec3(vec3(vec3(vec3(sign(VIB_coeffVibrance) * color_saturation) - 1.0) * VIB_coeffVibrance) + 1.0);
+    vec3 p_col = (sign(VIB_coeffVibrance) * color_saturation - 1.0) * VIB_coeffVibrance + 1.0;
 
-    pixColor[0] = mix(luma, color[0], p_col[0]);
-    pixColor[1] = mix(luma, color[1], p_col[1]);
-    pixColor[2] = mix(luma, color[2], p_col[2]);
-
-    gl_FragColor = pixColor;
+    vec3 adjustedColor = mix(vec3(luma), color, p_col);
+    fragColor = vec4(adjustedColor, pixColor.a);
 }
 
 // vim: ft=glsl


### PR DESCRIPTION
[Hyprland 0.50.0](https://hypr.land/news/update50/) requires at least GLES 3.0, which breaks the shaders in Hyprshade. This commit fixes this by changing `#version` to `300 es` and using modern syntax and conventions for OpenGL 3.0.