### PR TITLE
expand ~ and environment variables in the path

### DIFF
--- a/src/hyprshade/shader/hyprctl.py
+++ b/src/hyprshade/shader/hyprctl.py
@@ -4,6 +4,7 @@ import json
 import subprocess
 import textwrap
 from json import JSONDecodeError
+from os import path
 from typing import Final
 
 import click
@@ -95,4 +96,4 @@ def get_screen_shader() -> str | None:
     if shader == EMPTY_STR:
         return None
 
-    return shader
+    return path.expanduser(path.expandvars(shader))


### PR DESCRIPTION
## Issue
When setting a screen shader via `hyprctl keyword decoration:screen_shader`, paths containing `~` (home directory shorthand) are stored literally by hyprctl and returned unchanged by `hyprctl getoption decoration:screen_shader`.

Hyprshade's `get_screen_shader()` function returns this path as-is, but the Shader class doesn't expand it before trying to resolve the file, causing a `FileNotFoundError`.

## Example Error
```
FileNotFoundError: No file found at '/var/home/me/~/.config/hypr/shaders/retro.frag'
```

Note the literal `~` in the path instead of being expanded to the home directory.

## Root Cause
In `hyprshade/shader/hyprctl.py`, the `get_screen_shader()` function returns the path string without expanding environment variables or the `~` home directory shorthand:

```python
def get_screen_shader() -> str | None:
    # ... code ...
    shader = str(shader_json["str"]).strip()
    if shader == EMPTY_STR:
        return None

    return shader  # ← Returns unexpanded path
```

## Solution
Add path expansion using `os.path.expanduser()` and `os.path.expandvars()`:

## Testing
After applying the fix:
- Shaders with `~` paths work correctly
- `uv run hyprshade current` properly resolves the path
- `uv run hyprshade ls` no longer crashes when a shader with `~` is active

## Files Changed
- `hyprshade/shader/hyprctl.py`: Added import and path expansion in `get_screen_shader()`

## Workaround (before fix)
Store custom shaders in `<hyprshade-install-location>/shaders/` which hyprshade searches by default.