### PR TITLE
Migrate to Hyprland 0.55

### DIFF
--- a/src/hyprshade/shader/hyprctl.py
+++ b/src/hyprshade/shader/hyprctl.py
@@ -58,7 +58,7 @@ def hyprctl_error_context(*, command: str, stdout: str, stderr: str) -> str:
 def lua_escape_str(s: str) -> str:
     return s.translate(
         str.maketrans(
-            {
+            {  # type: ignore[arg-type]
                 "\\": r"\\",
                 "'": r"\'",
             }

--- a/src/hyprshade/shader/hyprctl.py
+++ b/src/hyprshade/shader/hyprctl.py
@@ -55,10 +55,25 @@ def hyprctl_error_context(*, command: str, stdout: str, stderr: str) -> str:
 {textwrap.indent(stderr, " " * 4)}""".strip()
 
 
+def lua_escape_str(s: str) -> str:
+    return s.translate(
+        str.maketrans(
+            {
+                "\\": r"\\",
+                "'": r"\'",
+            }
+        )
+    )
+
+
 def set_screen_shader(shader_path: str) -> None:
     try:
         subprocess.run(
-            ["hyprctl", "keyword", "decoration:screen_shader", shader_path],
+            [
+                "hyprctl",
+                "eval",
+                f"hl.config({{decoration = '{lua_escape_str(shader_path)}'}})",
+            ],
             capture_output=True,
             check=True,
             encoding="utf-8",
@@ -74,7 +89,7 @@ def clear_screen_shader() -> None:
 def get_screen_shader() -> str | None:
     try:
         hyprctl_pipe = subprocess.run(
-            ["hyprctl", "-j", "getoption", "decoration:screen_shader"],
+            ["hyprctl", "-j", "getoption", "decoration.screen_shader"],
             capture_output=True,
             check=True,
             encoding="utf-8",

--- a/tests/shader/test_shader.py
+++ b/tests/shader/test_shader.py
@@ -19,7 +19,7 @@ class TestPureShaderConstructor:
         assert shader._given_path is None
 
     def test_invalid_name(self):
-        with pytest.raises(ValueError, match="must not contain a '.' character"):
+        with pytest.raises(ValueError, match=r"must not contain a '.' character"):
             _shader = PureShader("foo.glsl")
 
     def test_path(self, tmp_path: Path):


### PR DESCRIPTION
Hyprland 0.55 introduced a breaking change: the `hyprctl keyword` command no longer works (unless you are [using the legacy parser](https://github.com/hyprwm/Hyprland/blob/5e441cae538c9396f2ee30338419bec12969608c/src/debug/HyprCtl.cpp#L1138-L1139)) and the [`hyprctl getoption`](https://wiki.hypr.land/Configuring/Advanced-and-Cool/Using-hyprctl/#info) command has different syntax.

This PR uses `hyprctl eval` instead of `hyprctl keyword` and fixes the `hyprctl getoption` syntax, breaking compatibility with older Hyprland versions.

---

Fixes #68.